### PR TITLE
Update eve-recovery-files loop dev regex

### DIFF
--- a/ansible/roles/eve-recovery-files/tasks/main.yml
+++ b/ansible/roles/eve-recovery-files/tasks/main.yml
@@ -35,7 +35,7 @@
   set_fact:
     mapper_device: "{{ kpartx_output.stdout | regex_search(regexp, '\\1') | first }}"
   vars:
-    regexp: '(loop[0-9]p3)'
+    regexp: '(loop[0-9]+p3)'
 
 - debug:
     msg: "mapper device: {{ mapper_device }}"


### PR DESCRIPTION
Change mapper device regex so that it recognises loop devices loop9+. If re-running the script on an already used system which has snaps etc. installed taking up loop devices, the device number might be higher than 9, causing the script to fail.